### PR TITLE
Fix: For missing email (soft-deleted user)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,7 @@
 Changelog
 =========
+### 1.0.2 (4/24/2025)
+- Fix: For missing email (soft-deleted user)
+
 ### 1.0.1 (4/22/2025)
 - Fix: Online indicator not showing

--- a/helpers/ProfileImageHelper.php
+++ b/helpers/ProfileImageHelper.php
@@ -5,11 +5,23 @@ namespace humhub\modules\gravatar\helpers;
 use humhub\libs\ProfileImage;
 use humhub\modules\gravatar\Module;
 use humhub\modules\user\models\User;
+use humhub\libs\Html;
 use Yii;
-use yii\helpers\Html;
 
 class ProfileImageHelper
 {
+    /**
+     * Tracks which user IDs have already had missing email warnings logged
+     * @var array
+     */
+    private static $warnedMissingEmailUsers = [];
+
+    /**
+     * Flag to track if empty email warning has been logged
+     * @var bool
+     */
+    private static $warnedEmptyEmail = false;
+
     /**
      * Get the profile image URL or Gravatar fallback.
      *
@@ -25,7 +37,20 @@ class ProfileImageHelper
             return $profileImage->getUrl();
         }
 
-        return self::getGravatarUrl($user->email, $size);
+        if (isset($user->email) && $user->email !== null) {
+            return self::getGravatarUrl($user->email, $size);
+        }
+
+        if (!isset(self::$warnedMissingEmailUsers[$user->id])) {
+            Yii::warning(
+                'Missing email for user ' . Html::encode($user->displayName) . '. ' . 'Possible soft-deleted account or registration issue. Using default image instead.',
+                'gravatar'
+            );
+
+            self::$warnedMissingEmailUsers[$user->id] = true;
+        }
+
+        return self::getDefaultImageUrl($size);
     }
 
     /**
@@ -40,7 +65,6 @@ class ProfileImageHelper
     {
         $htmlOptions['width'] = $size;
         $htmlOptions['height'] = $size;
-        $htmlOptions['class'] = $htmlOptions['class'] ?? 'img-circle';
 
         return Html::img(self::getProfileImageUrl($user, $size), $htmlOptions);
     }
@@ -56,6 +80,14 @@ class ProfileImageHelper
      */
     public static function getGravatarUrl(string $email, int $size = 150, ?string $style = null, ?string $rating = null): string
     {
+        if (empty($email)) {
+            if (!self::$warnedEmptyEmail) {
+                Yii::warning("Empty email provided to getGravatarUrl(). Using default image instead.", 'gravatar');
+                self::$warnedEmptyEmail = true;
+            }
+            return self::getDefaultImageUrl($size, $style, $rating);
+        }
+
         $hash = md5(strtolower(trim($email)));
 
         /** @var Module $module */
@@ -65,6 +97,25 @@ class ProfileImageHelper
         $rating = $rating ?? $module->settings->get('defaultRating', $module->defaultRating);
 
         return "https://www.gravatar.com/avatar/$hash?s=$size&d=$style&r=$rating";
+    }
+
+    /**
+     * Get the default image URL when no email is available
+     * 
+     * @param int $size
+     * @param string|null $style
+     * @param string|null $rating
+     * @return string
+     */
+    public static function getDefaultImageUrl(int $size = 150, ?string $style = null, ?string $rating = null): string
+    {
+        /** @var Module $module */
+        $module = Yii::$app->getModule('gravatar');
+
+        $style = $style ?? $module->settings->get('defaultStyle', $module->defaultStyle);
+        $rating = $rating ?? $module->settings->get('defaultRating', $module->defaultRating);
+
+        return "https://www.gravatar.com/avatar/00000000000000000000000000000000?s=$size&d=$style&r=$rating";
     }
 
     /**
@@ -83,5 +134,17 @@ class ProfileImageHelper
         }
 
         return true;
+    }
+    
+    /**
+     * Returns a user display name as a link to their profile using HumHub's Html::containerLink
+     * 
+     * @param User $user
+     * @param array $options HTML options for the link
+     * @return string
+     */
+    public static function getUserDisplayNameLink(User $user, array $options = []): string
+    {
+        return Html::containerLink($user, $options);
     }
 }

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "name": "Gravatar Integration",
     "description": "Displays Gravatar profile images as fallback when users don't have a custom profile picture",
     "keywords": ["profile", "image", "avatar", "gravatar"],
-    "version": "1.0.1",
+    "version": "1.0.2",
     "humhub": {
         "minVersion": "1.16"
     },


### PR DESCRIPTION
This should implement a silent check for `$user->email` if one exists, if it doesn't then it will assume that there was an issue where email was not linked to account which then uses gravatar anyway but gives an admin a warning in their logs about the issue clearly and states which user(s) it is that is causing the issue.

resolve #1